### PR TITLE
Fix: restrict demo mode activation to appropriate test state

### DIFF
--- a/software/firmware/tester_runtime/src/main.c
+++ b/software/firmware/tester_runtime/src/main.c
@@ -49,8 +49,10 @@ static void startupSequence(void) {
         // Check for button combos to start tests, demo mode, or PoV easter egg
         if (!testActive && buttons[3].pressed) {
             test_cases_start(currentTest);
-        } else if (!testActive && buttons[0].pressed && buttons[2].pressed) {
-            while(1)  {
+        } else if (!testActive && currentTest == 0 && buttons[0].pressed && buttons[2].pressed) {
+            // Only allow demo mode when no test is selected/run (currentTest == 0)
+            // This prevents entering an un-exitable demo mode when the device is idle with no tests executed.
+            while (1) {
                 demoMode();
             }
         } else if (allTestsPassed() && buttons[1].pressed && buttons[2].pressed) {

--- a/software/firmware/tester_runtime/src/main.c
+++ b/software/firmware/tester_runtime/src/main.c
@@ -51,7 +51,7 @@ static void startupSequence(void) {
             test_cases_start(currentTest);
         } else if (!testActive && currentTest == 0 && buttons[0].pressed && buttons[2].pressed) {
             // Only allow demo mode when no test is selected/run (currentTest == 0)
-            // This prevents entering an un-exitable demo mode when the device is idle with no tests executed.
+            // This prevents entering an un-exitable demo mode when the device is idle but tests already executed.
             while (1) {
                 demoMode();
             }


### PR DESCRIPTION
This change adjusts the demo-mode activation condition so demo mode is only entered when  (no test selected). This prevents accidental or un-exitable demo mode when tests are already active or selected.\n\nFixes #3